### PR TITLE
Fixed databaseUrl in the exports.dataSources

### DIFF
--- a/docs/data-source-firebase.md
+++ b/docs/data-source-firebase.md
@@ -29,7 +29,7 @@ exports.dataSources = {
   firebase: args => new FirebaseDataSource({
     config: {
       credential: admin.credential.cert(cert),
-      databaseURL,
+      databaseUrl,
     },
     path: args.key,
   }),


### PR DESCRIPTION
The databaseUrl in the exports.dataSources had the wrong case